### PR TITLE
Fix for incomplete path to slate.svg font

### DIFF
--- a/source/slate/css/_icon-font.scss
+++ b/source/slate/css/_icon-font.scss
@@ -5,7 +5,7 @@
     url('../fonts/slate.woff2?-syv14m') format('woff2'),
     url('../fonts/slate.woff?-syv14m') format('woff'),
     url('../fonts/slate.ttf?-syv14m') format('truetype'),
-    url('../slate.svg?-syv14m#slate') format('svg');
+    url('../fonts/slate.svg?-syv14m#slate') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Fixed path pointing to root of slate folder instead of fonts within it for `slate.svg`.